### PR TITLE
Changed project popover format on dashboards

### DIFF
--- a/templates/hcat/base_site.html
+++ b/templates/hcat/base_site.html
@@ -13,7 +13,6 @@
             $('[data-toggle="popover"]').popover({
                 placement : 'top',
                 trigger : 'hover',
-                offset: '-100'
             });
         });
     </script>

--- a/templates/hcat/cbrowser_page.html
+++ b/templates/hcat/cbrowser_page.html
@@ -24,10 +24,12 @@
             <tbody>
                 {% for proj in cbrowser_projects %}
                 <tr>
-                    <td data-toggle="popover" title="{{ proj.title }}"
-                                data-content="{{ proj.description|truncatewords:100 }}">
-                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}">
-                            {{ proj.short_name|truncatechars:50 }}</a></td>
+                    <td>
+                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
+                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                                data-content="{{ proj.description|truncatechars:300 }}">
+                            {{ proj.short_name|truncatechars:50 }}</a>
+                    </td>
                     <td>{{ proj.species.all|join:"<br>" }}</td>
                     <td>{{ proj.disease.all|join:"<br>" }}</td>
                     <td>{{ proj.cdna_library_prep.all|join:"<br>" }}</td>

--- a/templates/hcat/cbrowser_page.html
+++ b/templates/hcat/cbrowser_page.html
@@ -26,7 +26,7 @@
                 <tr>
                     <td>
                         <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
-                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                           data-toggle="popover" title="{{ proj.title }}"
                                 data-content="{{ proj.description|truncatechars:300 }}">
                             {{ proj.short_name|truncatechars:50 }}</a>
                     </td>

--- a/templates/hcat/covid19_page.html
+++ b/templates/hcat/covid19_page.html
@@ -26,7 +26,7 @@
                 <tr>
                     <td>
                         <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
-                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                           data-toggle="popover" title="{{ proj.title }}"
                                 data-content="{{ proj.description|truncatechars:300 }}">
                             {{ proj.short_name|truncatechars:50 }}</a>
                     </td>

--- a/templates/hcat/covid19_page.html
+++ b/templates/hcat/covid19_page.html
@@ -24,10 +24,12 @@
             <tbody>
                 {% for proj in covid_projects %}
                 <tr>
-                    <td data-toggle="popover" title="{{ proj.title }}"
-                                data-content="{{ proj.description|truncatewords:100 }}">
-                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}">
-                            {{ proj.short_name|truncatechars:50 }}</a></td>
+                    <td>
+                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
+                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                                data-content="{{ proj.description|truncatechars:300 }}">
+                            {{ proj.short_name|truncatechars:50 }}</a>
+                    </td>
                     <td>{{ proj.species.all|join:"<br>" }}</td>
                     <td>{{ proj.disease.all|join:"<br>" }}</td>
                     <td>{{ proj.cdna_library_prep.all|join:"<br>" }}</td>

--- a/templates/hcat/gbrowser_page.html
+++ b/templates/hcat/gbrowser_page.html
@@ -24,10 +24,12 @@
             <tbody>
                 {% for proj in gbrowser_projects %}
                 <tr>
-                    <td data-toggle="popover" title="{{ proj.title }}"
-                                data-content="{{ proj.description|truncatewords:100 }}">
-                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}">
-                            {{ proj.short_name|truncatechars:50 }}</a></td>
+                    <td>
+                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
+                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                                data-content="{{ proj.description|truncatechars:300 }}">
+                            {{ proj.short_name|truncatechars:50 }}</a>
+                    </td>
                     <td>{{ proj.species.all|join:"<br>" }}</td>
                     <td>{{ proj.disease.all|join:"<br>" }}</td>
                     <td>{{ proj.cdna_library_prep.all|join:"<br>" }}</td>

--- a/templates/hcat/gbrowser_page.html
+++ b/templates/hcat/gbrowser_page.html
@@ -26,7 +26,7 @@
                 <tr>
                     <td>
                         <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
-                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                           data-toggle="popover" title="{{ proj.title }}"
                                 data-content="{{ proj.description|truncatechars:300 }}">
                             {{ proj.short_name|truncatechars:50 }}</a>
                     </td>

--- a/templates/hcat/projectAll_page.html
+++ b/templates/hcat/projectAll_page.html
@@ -23,7 +23,7 @@
                 <tr>
                     <td>
                         <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
-                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                           data-toggle="popover" title="{{ proj.title }}"
                                 data-content="{{ proj.description|truncatechars:300 }}">
                             {{ proj.short_name|truncatechars:50 }}</a>
                     </td>

--- a/templates/hcat/projectAll_page.html
+++ b/templates/hcat/projectAll_page.html
@@ -8,17 +8,10 @@
 </head>
 <body>{% block body %}
     <div class="container project_test mt-5">
-<!--        <div class="input-group mb-3" style="width: 400px;">-->
-<!--            <input type="text" placeholder="Search..." class="form-control">-->
-<!--            <div class="input-group-append">-->
-<!--                <button type="submit" class="btn btn-primary"><i class="fa fa-search"></i></button>-->
-<!--            </div>-->
-<!--        </div>-->
         {% if projects %}
         <table class="table table-hover">
             <thead class="thead-dark">
                 <tr>
-<!--                    <th></th>-->
                     <th>Short Name</th>
                     <th>Stars</th>
                     <th>Status</th>
@@ -28,10 +21,12 @@
             <tbody>
                 {% for proj in projects %}
                 <tr>
-<!--                    <td><input type="checkbox"></td>-->
-                    <td data-toggle="popover" title="{{ proj.title }}"
-                                data-content="{{ proj.description|truncatewords:100 }}">
-                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}">{{ proj.short_name|truncatechars:50 }}</a></td>
+                    <td>
+                        <a href="{% url 'hcat:project_detail' proj.short_name|urlencode:'' %}"
+                           data-toggle="popover" data-title="{{ proj.title }}" data-selector="true"
+                                data-content="{{ proj.description|truncatechars:300 }}">
+                            {{ proj.short_name|truncatechars:50 }}</a>
+                    </td>
                     <td>{{ proj.stars }}</td>
                     <td>{{ proj.status }}</td>
                     <td>{{ proj.primary_wrangler }}</td>
@@ -43,7 +38,6 @@
             <p>No projects found...</p>
         {% endif %}
 
-        <!-- Will need to build out javascript for finding pages and when to activate and disable navigation-->
         {% if projects.has_other_pages %}
         <nav>
           <ul class="pagination justify-content-end">


### PR DESCRIPTION
Changed the description truncation for popovers on all the dashboard pages. Adjusted the popover trigger location to occur on the short name link.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
Implemented some alterations to the popovers on the different dashboard pages. Specifically, I changed the popover's target to be the short name link, changed the orientation to be auto, and truncated the description to 300 characters. Should fix #47.